### PR TITLE
fix: 修复因为打包第三方库导致的游戏崩溃

### DIFF
--- a/minecraft-mod/build.gradle
+++ b/minecraft-mod/build.gradle
@@ -71,9 +71,9 @@ configurations.configureEach {
 //                    logger.warn("检测到 ${group}:${name} 请求版本 ${details.requested.version}，已强制升级至 >= ${LZ4_requiredVersion}")
 //                }
 //            }
-            if (group == 'com.fasterxml.jackson.core' && name == 'jackson-core') {
-                // 直接指定版本范围
-                details.useVersion "[${Jackson_requiredVersion},)"
+            if (group == 'com.fasterxml.jackson.core' && (name == 'jackson-core' || name == 'jackson-databind' || name == 'jackson-annotations')) {
+                // 固定 Jackson 三件套到相同版本，避免运行时方法签名不兼容
+                details.useVersion "${Jackson_requiredVersion}"
 
                 // 可选：简化的版本警告（避免内部类）
                 if (details.requested.version) {
@@ -113,6 +113,12 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
     include "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
+
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.18.6"
+    include "com.fasterxml.jackson.core:jackson-annotations:2.18.6"
+
+    implementation "com.fasterxml.jackson.core:jackson-core:2.18.6"
+    include "com.fasterxml.jackson.core:jackson-core:2.18.6"
 
     implementation "com.fasterxml.jackson.core:jackson-databind:2.18.6"
     include "com.fasterxml.jackson.core:jackson-databind:2.18.6"

--- a/minecraft-mod/gradle.properties
+++ b/minecraft-mod/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.17.2
 
 # Mod Properties
-	mod_version = 0.4.0
+	mod_version = 0.4.1
 	maven_group = fun.prof_chen
 	archives_base_name = MCTeamViewer
 


### PR DESCRIPTION
## Summary by Sourcery

Align bundled Jackson dependencies to a single pinned version and bump the mod patch version.

Bug Fixes:
- Prevent runtime crashes by forcing all bundled Jackson core, databind, and annotations artifacts to use the same version.

Build:
- Add explicit jackson-annotations and jackson-core dependencies and includes at the pinned Jackson version.

Chores:
- Bump the Minecraft mod version from 0.4.0 to 0.4.1.