### PR TITLE
修复崩溃问题

### DIFF
--- a/minecraft-mod/build.gradle
+++ b/minecraft-mod/build.gradle
@@ -71,9 +71,9 @@ configurations.configureEach {
 //                    logger.warn("检测到 ${group}:${name} 请求版本 ${details.requested.version}，已强制升级至 >= ${LZ4_requiredVersion}")
 //                }
 //            }
-            if (group == 'com.fasterxml.jackson.core' && name == 'jackson-core') {
-                // 直接指定版本范围
-                details.useVersion "[${Jackson_requiredVersion},)"
+            if (group == 'com.fasterxml.jackson.core' && (name == 'jackson-core' || name == 'jackson-databind' || name == 'jackson-annotations')) {
+                // 固定 Jackson 三件套到相同版本，避免运行时方法签名不兼容
+                details.useVersion "${Jackson_requiredVersion}"
 
                 // 可选：简化的版本警告（避免内部类）
                 if (details.requested.version) {
@@ -113,6 +113,12 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
     include "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
+
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.18.6"
+    include "com.fasterxml.jackson.core:jackson-annotations:2.18.6"
+
+    implementation "com.fasterxml.jackson.core:jackson-core:2.18.6"
+    include "com.fasterxml.jackson.core:jackson-core:2.18.6"
 
     implementation "com.fasterxml.jackson.core:jackson-databind:2.18.6"
     include "com.fasterxml.jackson.core:jackson-databind:2.18.6"

--- a/minecraft-mod/build.gradle
+++ b/minecraft-mod/build.gradle
@@ -117,11 +117,11 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:2.18.6"
     include "com.fasterxml.jackson.core:jackson-databind:2.18.6"
 
-    implementation "org.msgpack:jackson-dataformat-msgpack:0.9.8"
-    include "org.msgpack:jackson-dataformat-msgpack:0.9.8"
+    implementation "org.msgpack:jackson-dataformat-msgpack:0.9.11"
+    include "org.msgpack:jackson-dataformat-msgpack:0.9.11"
 
-    implementation "org.msgpack:msgpack-core:0.9.8"
-    include "org.msgpack:msgpack-core:0.9.8"
+    implementation "org.msgpack:msgpack-core:0.9.11"
+    include "org.msgpack:msgpack-core:0.9.11"
 }
 
 processResources {

--- a/minecraft-mod/gradle.properties
+++ b/minecraft-mod/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.17.2
 
 # Mod Properties
-	mod_version = 0.4.0
+	mod_version = 0.4.1
 	maven_group = fun.prof_chen
 	archives_base_name = MCTeamViewer
 


### PR DESCRIPTION
## Summary by Sourcery

Align Jackson and MsgPack dependencies to compatible versions to resolve a runtime crash.

Bug Fixes:
- Fix runtime crashes caused by incompatible Jackson component versions by enforcing a single Jackson version across core, databind, and annotations.

Build:
- Pin Jackson core, databind, and annotations to the same version and update MsgPack dependencies to 0.9.11 in the Gradle build.
- Bump the mod version from 0.4.0 to 0.4.1 in gradle.properties.