### PR TITLE
添加了ESP本地数据优先的功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,146 @@
-# Minecraft_TeamViewer
-本项目可以共享团队视野，目前仅在 1.21.8 版本上进行测试
+# Minecraft TeamViewer
 
-web-server 文件夹下的 python 代码是用于配置服务端的，客户端把自己所看到的内容发送给服务端，服务端再把其他人看到的内容发送给客户端和管理端。
+用于 Minecraft 团队协同作战的“视野与报点共享”系统，当前以 **1.21.8 Fabric** 为主版本进行开发和验证。
 
-web-server/src/static/nodemc_map_projection.js 是一个油猴脚本，用于在MC服务器的地图上添加玩家视野信息。
+本仓库包含三部分：
 
-剩下的就是这个 Minecraft 1.21.8 Fabric Mod 的代码本体了。
+- `minecraft-mod/`：客户端 Fabric Mod（玩家框线渲染、共享报点、房间隔离、与 Xaero 联动）
+- `backend-server/`：Python FastAPI WebSocket 服务端（聚合并广播玩家/实体/路标数据）
+- `tampermonkey-script/`：管理端油猴脚本工程（接入 `adminws`，可进行战术标注等）
+
+## 1. 核心功能
+
+- 团队玩家信息共享：同步玩家位置、实体信息、共享路标
+- 客户端 ESP：远程玩家方框 + 追踪线 + 敌友颜色映射
+- 快速报点：按键/中键双击一键报点，支持中键取消、超时清理、数量上限
+- Xaero 联动（可选）：
+	- 与 Xaero Minimap 双向同步共享路标
+	- 与 Xaero World Map 同步远程玩家追踪
+- 房间隔离：通过 `roomCode` 分房，互不干扰
+- 管理端通道：`/adminws` 实时订阅状态，支持战术路标下发
+
+## 2. 版本与环境
+
+- Minecraft：`1.21.8`
+- Fabric Loader：`0.17.2`
+- Fabric API：`0.131.0+1.21.8`
+- Java：`21`（mod 构建目标）
+- Python：`>=3.12`（后端）
+- Node.js + pnpm（油猴脚本构建）
+
+## 3. 快速开始（完整链路）
+
+### 3.1 启动后端服务
+
+后端默认监听 `0.0.0.0:8765`。
+
+```bash
+cd backend-server/src
+uv run main.py
+```
+
+可选健康检查：
+
+```bash
+curl http://127.0.0.1:8765/health
+```
+
+主要端点：
+
+- 玩家客户端：`ws://127.0.0.1:8765/playeresp`
+- 管理端：`ws://127.0.0.1:8765/adminws`
+- 快照调试：`http://127.0.0.1:8765/snapshot`
+
+### 3.2 构建或获取 Mod
+
+```bash
+cd minecraft-mod
+chmod +x ./gradlew
+./gradlew build
+```
+
+输出 jar 位于 `minecraft-mod/build/libs/`（`Taskfile.yml` 也支持一键打包到 `build-artifacts/`）。
+
+### 3.3 安装 Mod（客户端）
+
+至少安装：
+
+- Fabric Loader
+- Fabric API
+- 本项目 Mod jar
+
+推荐安装（可选）：
+
+- Mod Menu（用于在 Mod 列表中直接打开配置页）
+- Xaero Minimap（共享路标联动）
+- Xaero World Map（远程玩家追踪联动）
+
+### 3.4 游戏内首次配置
+
+1. 进入游戏后按 `O` 打开配置页（默认快捷键）。
+2. 将服务器地址改为：`ws://127.0.0.1:8765/playeresp`。
+3. 选择房间号（默认 `default`，同房间互相可见）。
+4. 点击“保存服务器设置”，再点击“连接”。
+
+> 注意：当前配置默认值是 `ws://localhost:8080/playeresp`，若后端按默认端口 `8765` 启动，需要手动改地址。
+
+## 4. Mod 介绍与使用
+
+### 4.1 基本操作
+
+- `O`：打开配置面板（默认已绑定）
+- 连接开关快捷键：默认未绑定，请在控制设置中手动绑定
+- 快速报点快捷键：默认未绑定，请在控制设置中手动绑定
+
+只有在“ESP 已启用且网络已连接”时，报点与同步会生效。
+
+### 4.2 显示能力
+
+- 远程玩家方框（Box）
+- 追踪线（Tracer）
+- 敌我中立颜色映射（friendly / neutral / enemy）
+- 报点渲染样式可切换：`beacon` / `ring` / `pin`
+- 可选“穿墙显示报点和方框”（xray）
+
+### 4.3 报点机制
+
+- 快捷报点：按“快速报点”按键，或启用“中键双击报点”
+- 取消报点：启用后可“中键单击取消准星附近本人报点”
+- 自动取消：实体报点在本地确认目标死亡后可自动撤销
+- 数量限制：每位玩家快捷报点超过上限时，会自动清理较旧报点
+- 超时清理：普通报点与长期报点分别支持独立 TTL
+
+### 4.4 配置入口说明
+
+- 主配置页：服务端 URL、房间号、连接/断开
+- 显示设置页：渲染距离、方框/线条开关、追踪线起点、颜色/报点子页
+- 网络设置页：上报频率、实体上报开关、共享路标上报、系统代理
+- 报点设置页：报点显示、中键交互、长期报点、样式、形状参数
+
+配置文件为 `config/multipleplayeresp.json`（Fabric 标准配置目录）。
+
+## 5. 管理端脚本（Tampermonkey）
+
+开发与构建：
+
+```bash
+cd tampermonkey-script
+pnpm install
+pnpm build
+```
+
+构建产物在 `tampermonkey-script/dist/*.user.js`，导入 Tampermonkey 即可。
+
+默认管理端 WS：`ws://127.0.0.1:8765/adminws`。
+
+## 6. 常见问题
+
+- 连接失败：优先检查 Mod 配置的 `Server URL` 是否与后端端口一致（常见是 8080/8765 不一致）
+- 看不到队友：确认双方 `roomCode` 相同，且都已连接成功
+- 报点无效：需先启用 ESP + 建立连接；若使用按键报点，请先手动绑定快捷键
+- Xaero 功能不生效：确认已安装对应 Xaero 模组（`xaerominimap` / `xaeroworldmap`）
+
+## 7. 协议与设计文档
+
+- `docs/PLAYER_ESP_NETWORK_PROTOCOL.md`：网络协议与消息结构（0.4.x）
+- `docs/RENDER_MODULE_MIGRATION.md`：渲染模块迁移记录

--- a/backend-server/README.md
+++ b/backend-server/README.md
@@ -1,0 +1,51 @@
+# backend-server
+
+Minecraft TeamViewer 的后端聚合服务，基于 FastAPI + WebSocket。
+
+## 功能
+
+- 接收客户端上报的玩家/实体/路标数据
+- 按 `roomCode` 分房广播
+- 提供 `adminws` 管理通道（状态快照、指令）
+- 支持增量同步（`snapshot_full` / `patch` / `digest`）
+
+## 环境
+
+- Python `>=3.12`
+- 推荐使用 `uv`
+
+## 启动
+
+```bash
+cd backend-server/src
+uv run main.py
+```
+
+默认监听：`0.0.0.0:8765`
+
+## 关键端点
+
+- 玩家 WS：`/playeresp`
+- 管理 WS：`/adminws`
+- 健康检查：`/health`
+- 快照调试：`/snapshot`
+
+## 运行配置
+
+配置文件：`src/server/server_state_config.toml`
+
+可配置项包括：
+
+- 对象超时（玩家 / 实体 / 路标）
+- digest 间隔
+- 广播频率与拥塞降级阈值
+- 同服过滤开关（Tab 列表归并）
+
+## 协议版本
+
+当前服务端协议常量位于 `src/main.py`：
+
+- `NETWORK_PROTOCOL_VERSION = 0.4.0`
+- `SERVER_MIN_COMPATIBLE_PROTOCOL_VERSION = 0.4.0`
+
+详细字段与报文结构见仓库根目录文档：`docs/PLAYER_ESP_NETWORK_PROTOCOL.md`

--- a/minecraft-mod/gradle.properties
+++ b/minecraft-mod/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.17.2
 
 # Mod Properties
-	mod_version = 0.4.2
+	mod_version = 0.4.3
 	maven_group = fun.prof_chen
 	archives_base_name = MCTeamViewer
 

--- a/minecraft-mod/src/client/java/fun/prof_chen/teamviewer/multipleplayeresp/config/Config.java
+++ b/minecraft-mod/src/client/java/fun/prof_chen/teamviewer/multipleplayeresp/config/Config.java
@@ -54,6 +54,7 @@ public class Config {
     private double tampermonkeyBeamWidth = 0.34D; // 网页下发顶天立地光柱宽度（半径）
     private double tampermonkeyBeamHeight = 384.0D; // 网页下发顶天立地光柱高度
     private boolean useSystemProxy = false; // 连接服务器时是否使用系统代理
+    private boolean preferLocalDataForEsp = true; // 本地可见玩家优先使用本地数据（降低远程延迟影响）
     
     public static Config load() {
         if (!Files.exists(CONFIG_PATH)) {
@@ -488,5 +489,13 @@ public class Config {
 
     public void setUseSystemProxy(boolean useSystemProxy) {
         this.useSystemProxy = useSystemProxy;
+    }
+
+    public boolean isPreferLocalDataForEsp() {
+        return preferLocalDataForEsp;
+    }
+
+    public void setPreferLocalDataForEsp(boolean preferLocalDataForEsp) {
+        this.preferLocalDataForEsp = preferLocalDataForEsp;
     }
 }

--- a/minecraft-mod/src/client/java/fun/prof_chen/teamviewer/multipleplayeresp/core/StandaloneMultiPlayerESP.java
+++ b/minecraft-mod/src/client/java/fun/prof_chen/teamviewer/multipleplayeresp/core/StandaloneMultiPlayerESP.java
@@ -149,7 +149,7 @@ public class StandaloneMultiPlayerESP implements ClientModInitializer {
 			handleAutoCancelWaypointOnEntityDeath(client);
 
 			// 同步远程玩家到Xaero世界地图
-			XaeroWorldMapBridge.tick(remotePlayers, espEnabled);
+			XaeroWorldMapBridge.tick(resolvePlayersForWorldMapBridge(), espEnabled);
 			XaeroWaypointShareBridge.tick(networkManager, espEnabled, config);
 			
 			// 发送玩家位置到服务器
@@ -382,7 +382,7 @@ public class StandaloneMultiPlayerESP implements ClientModInitializer {
 		boolean depthTestEnabled = !config.isXrayMarkersAndBoxes();
 		
 		Vec3d cameraPos = context.camera().getPos();
-		Map<UUID, Vec3d> positions = useServerPositions ? serverPlayerPositions : playerPositions;
+		Map<UUID, Vec3d> positions = useServerPositions ? serverPlayerPositions : resolvePlayersForRender();
 		
 		// 渲染玩家位置框
 		for (Map.Entry<UUID, Vec3d> entry : positions.entrySet()) {
@@ -435,6 +435,41 @@ public class StandaloneMultiPlayerESP implements ClientModInitializer {
 		}
 
 		renderSharedWaypointMarkers(context, cameraPos, depthTestEnabled);
+	}
+
+	private Map<UUID, Vec3d> resolvePlayersForRender() {
+		if (config == null || !config.isPreferLocalDataForEsp()) {
+			return playerPositions;
+		}
+
+		Map<UUID, Vec3d> mergedPositions = new HashMap<>(playerPositions);
+		mergedPositions.putAll(serverPlayerPositions);
+		return mergedPositions;
+	}
+
+	private Map<UUID, RemotePlayerInfo> resolvePlayersForWorldMapBridge() {
+		if (config == null || !config.isPreferLocalDataForEsp()) {
+			return remotePlayers;
+		}
+
+		Map<UUID, RemotePlayerInfo> mergedPlayers = new HashMap<>(remotePlayers);
+		MinecraftClient client = MinecraftClient.getInstance();
+		if (client.world != null) {
+			for (AbstractClientPlayerEntity player : client.world.getPlayers()) {
+				if (player == null || player == client.player) {
+					continue;
+				}
+				RemotePlayerInfo localInfo = new RemotePlayerInfo(
+					player.getUuid(),
+					player.getPos(),
+					player.getWorld().getRegistryKey(),
+					player.getName().getString()
+				);
+				mergedPlayers.put(player.getUuid(), localInfo);
+			}
+		}
+
+		return mergedPlayers;
 	}
 
 	private int resolveRenderColorByTeam(String teamTag, int fallbackColor) {

--- a/minecraft-mod/src/client/java/fun/prof_chen/teamviewer/multipleplayeresp/ui/PlayerESPNetworkConfigScreen.java
+++ b/minecraft-mod/src/client/java/fun/prof_chen/teamviewer/multipleplayeresp/ui/PlayerESPNetworkConfigScreen.java
@@ -14,6 +14,7 @@ public class PlayerESPNetworkConfigScreen extends Screen {
     private TextFieldWidget updateIntervalField;
     private ButtonWidget uploadEntitiesButton;
     private ButtonWidget uploadSharedWaypointsButton;
+    private ButtonWidget preferLocalDataForEspButton;
     private ButtonWidget useSystemProxyButton;
 
     private static final int COMPONENT_WIDTH = 200;
@@ -33,6 +34,7 @@ public class PlayerESPNetworkConfigScreen extends Screen {
         int totalHeight = 0;
         totalHeight += COMPONENT_SPACING;
         totalHeight += COMPONENT_SPACING;
+        totalHeight += BUTTON_SPACING;
         totalHeight += BUTTON_SPACING;
         totalHeight += BUTTON_SPACING;
         totalHeight += BUTTON_SPACING;
@@ -102,6 +104,13 @@ public class PlayerESPNetworkConfigScreen extends Screen {
         ).dimensions(componentX, uploadSharedWaypointsY, COMPONENT_WIDTH, COMPONENT_HEIGHT).build();
         this.addDrawableChild(this.uploadSharedWaypointsButton);
 
+        int preferLocalDataY = getNextButtonY();
+        this.preferLocalDataForEspButton = ButtonWidget.builder(
+            Text.translatable("screen.multipleplayeresp.config.prefer_local_data_for_esp"),
+            button -> togglePreferLocalDataForEsp()
+        ).dimensions(componentX, preferLocalDataY, COMPONENT_WIDTH, COMPONENT_HEIGHT).build();
+        this.addDrawableChild(this.preferLocalDataForEspButton);
+
         int useSystemProxyY = getNextButtonY();
         this.useSystemProxyButton = ButtonWidget.builder(
             Text.translatable("screen.multipleplayeresp.config.use_system_proxy"),
@@ -117,6 +126,7 @@ public class PlayerESPNetworkConfigScreen extends Screen {
 
         updateUploadEntitiesButton();
         updateUploadSharedWaypointsButton();
+        updatePreferLocalDataForEspButton();
         updateUseSystemProxyButton();
     }
 
@@ -171,6 +181,12 @@ public class PlayerESPNetworkConfigScreen extends Screen {
         updateUseSystemProxyButton();
     }
 
+    private void togglePreferLocalDataForEsp() {
+        boolean currentStatus = StandaloneMultiPlayerESP.getConfig().isPreferLocalDataForEsp();
+        StandaloneMultiPlayerESP.getConfig().setPreferLocalDataForEsp(!currentStatus);
+        updatePreferLocalDataForEspButton();
+    }
+
     private void updateUploadEntitiesButton() {
         if (this.uploadEntitiesButton != null) {
             boolean isEnabled = StandaloneMultiPlayerESP.getConfig().isUploadEntities();
@@ -198,11 +214,21 @@ public class PlayerESPNetworkConfigScreen extends Screen {
         }
     }
 
+    private void updatePreferLocalDataForEspButton() {
+        if (this.preferLocalDataForEspButton != null) {
+            boolean isEnabled = StandaloneMultiPlayerESP.getConfig().isPreferLocalDataForEsp();
+            String buttonText = Text.translatable("screen.multipleplayeresp.config.prefer_local_data_for_esp").getString();
+            buttonText += isEnabled ? " [ON]" : " [OFF]";
+            this.preferLocalDataForEspButton.setMessage(Text.of(buttonText));
+        }
+    }
+
     @Override
     public void tick() {
         super.tick();
         updateUploadEntitiesButton();
         updateUploadSharedWaypointsButton();
+        updatePreferLocalDataForEspButton();
         updateUseSystemProxyButton();
     }
 }

--- a/minecraft-mod/src/main/resources/assets/teamviewer/lang/en_us.json
+++ b/minecraft-mod/src/main/resources/assets/teamviewer/lang/en_us.json
@@ -39,6 +39,7 @@
   "screen.multipleplayeresp.config.quick_mark_max_count.tooltip": "Maximum number of quick marks kept at once; older quick marks are auto-removed when exceeded.",
   "screen.multipleplayeresp.config.upload_entities": "Upload Entity Data",
   "screen.multipleplayeresp.config.upload_shared_waypoints": "Upload Shared Waypoints",
+  "screen.multipleplayeresp.config.prefer_local_data_for_esp": "Prefer Local Data for ESP",
   "screen.multipleplayeresp.config.show_shared_waypoints": "Show Shared Waypoints",
   "screen.multipleplayeresp.config.show_shared_waypoints.tooltip": "Control whether shared waypoints from other players are displayed (including minimap).",
   "screen.multipleplayeresp.config.show_own_shared_waypoints_on_minimap": "Show Own Shared Marks on Minimap",

--- a/minecraft-mod/src/main/resources/assets/teamviewer/lang/zh_cn.json
+++ b/minecraft-mod/src/main/resources/assets/teamviewer/lang/zh_cn.json
@@ -39,6 +39,7 @@
   "screen.multipleplayeresp.config.quick_mark_max_count.tooltip": "快捷报点允许同时保留的最大数量；超过后会自动清理较旧的快捷报点。",
   "screen.multipleplayeresp.config.upload_entities": "上传实体信息",
   "screen.multipleplayeresp.config.upload_shared_waypoints": "上报共享路标",
+  "screen.multipleplayeresp.config.prefer_local_data_for_esp": "ESP优先使用本地数据",
   "screen.multipleplayeresp.config.show_shared_waypoints": "显示共享路标",
   "screen.multipleplayeresp.config.show_shared_waypoints.tooltip": "控制是否显示其他玩家共享过来的路标（含小地图）。",
   "screen.multipleplayeresp.config.show_own_shared_waypoints_on_minimap": "在小地图显示自己的共享报点",


### PR DESCRIPTION
## Summary by Sourcery

Add configurable preference for using local client data for ESP and world map syncing, and refresh project documentation and versioning to match the current multi-component architecture.

New Features:
- Introduce a client configuration option to prefer locally visible player data for ESP rendering and Xaero world map integration, merging it with server-reported data when enabled.

Enhancements:
- Improve ESP rendering and world map syncing by resolving player positions from a merged local-and-server view when local data preference is enabled.
- Expose the new ESP data preference as a toggle in the network configuration UI with live state updates.
- Bump the Minecraft mod version from 0.4.2 to 0.4.3 to reflect the new behavior.

Documentation:
- Rewrite the root README to document the full system architecture, setup steps, and usage for the mod, backend server, and Tampermonkey script.
- Add a dedicated backend-server README describing capabilities, configuration, endpoints, and protocol versions.